### PR TITLE
Change `TODO` comment rule to enforce ticket number, instead of name

### DIFF
--- a/lint/comment.py
+++ b/lint/comment.py
@@ -12,11 +12,11 @@ detect = gamla.compose_left(
             gamla.filter(
                 gamla.alljuxt(
                     gamla.compose_left(str.lower, lambda s: re.search(r"\btodo\b", s)),
-                    lambda s: not re.search(r"(#|//)\sTODO\([a-zA-Z]+\):\s.*", s),
+                    lambda s: not re.search(r"(#|//)\sTODO\(([A-Z]+)-\d+\):\s.*", s),
                 ),
             ),
             gamla.map(
-                lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
+                lambda s: f"Malformatted `TODO` syntax (should be `TODO(<Jira-ticket>): ...`): [{s}]",
             ),
         ),
         gamla.compose_left(

--- a/lint/comment_test.py
+++ b/lint/comment_test.py
@@ -5,7 +5,7 @@ from lint import comment
 
 def test_good():
     for good_comment in [
-        "# TODO(uri): I am a good comment.",
+        "# TODO(DEV-100): I am a good comment.",
         "# I am good too.",
         "a = 3  # I am good.",
         "from nlu.config import logging_config  # noqa: F401",
@@ -14,7 +14,7 @@ def test_good():
         "        # https://example.com/example/index.html#/example/",
         "#: Bla bla.",
         "// Bla bla.",
-        "// TODO(David): I am a good comment.",
+        "// TODO(ENG-500): I am a good comment.",
     ]:
         gamla.pipe(
             good_comment,
@@ -29,9 +29,12 @@ def test_bad():
         "#todo: do something",
         "# TODO ROM: uncomment when vaccine faq fixed",
         "# TODO (rachel): Remove if not relevant after rescraping novant's vaccine faq.",
+        "# TODO(Uri): I am a bad comment.",
         "#no leading space",
         "// todo(david): I am a bad comment.",
         "//no leading space",
+        "// TODO(Uri): I am a bad comment.",
+        "// TODO(eng-100): I am ticket in lowercase case.",
     ]:
         gamla.pipe(
             bad_comment,


### PR DESCRIPTION
Change linter `TODO` comments rules to enforce a `TODO` comment with ticket number, not user name:

before:
```
TODO(Eyal): old rule comment
```

after:
```
TODO(INI-100): new rule comment
```