### PR TITLE
Revert "Change `TODO` comment rule to enforce ticket number, not name

### DIFF
--- a/lint/comment.py
+++ b/lint/comment.py
@@ -12,11 +12,11 @@ detect = gamla.compose_left(
             gamla.filter(
                 gamla.alljuxt(
                     gamla.compose_left(str.lower, lambda s: re.search(r"\btodo\b", s)),
-                    lambda s: not re.search(r"(#|//)\sTODO\(([A-Z]+)-\d+\):\s.*", s),
+                    lambda s: not re.search(r"(#|//)\sTODO\([a-zA-Z]+\):\s.*", s),
                 ),
             ),
             gamla.map(
-                lambda s: f"Malformatted `TODO` syntax (should be `TODO(<Jira-ticket>): ...`): [{s}]",
+                lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
             ),
         ),
         gamla.compose_left(

--- a/lint/comment_test.py
+++ b/lint/comment_test.py
@@ -5,7 +5,7 @@ from lint import comment
 
 def test_good():
     for good_comment in [
-        "# TODO(DEV-100): I am a good comment.",
+        "# TODO(uri): I am a good comment.",
         "# I am good too.",
         "a = 3  # I am good.",
         "from nlu.config import logging_config  # noqa: F401",
@@ -14,7 +14,7 @@ def test_good():
         "        # https://example.com/example/index.html#/example/",
         "#: Bla bla.",
         "// Bla bla.",
-        "// TODO(ENG-500): I am a good comment.",
+        "// TODO(David): I am a good comment.",
     ]:
         gamla.pipe(
             good_comment,
@@ -29,12 +29,9 @@ def test_bad():
         "#todo: do something",
         "# TODO ROM: uncomment when vaccine faq fixed",
         "# TODO (rachel): Remove if not relevant after rescraping novant's vaccine faq.",
-        "# TODO(Uri): I am a bad comment.",
         "#no leading space",
         "// todo(david): I am a bad comment.",
         "//no leading space",
-        "// TODO(Uri): I am a bad comment.",
-        "// TODO(eng-100): I am ticket in lowercase case.",
     ]:
         gamla.pipe(
             bad_comment,


### PR DESCRIPTION
This reverts commit f71dbcf0e64479239089b8f72f5ef8aee5ac5402.