### PR TITLE
ENGINE-2677-allow-markdown-in-prompts

### DIFF
--- a/lint/comment.py
+++ b/lint/comment.py
@@ -7,17 +7,15 @@ detect = gamla.compose_left(
     gamla.filter(gamla.compose_left(str.lower, lambda s: re.match(r"\s*(#|//).*", s))),
     gamla.remove(lambda s: re.search(r"# type: ignore", s)),
     gamla.remove(lambda s: re.search(r"noqa", s)),
-    gamla.bifurcate(
-        gamla.compose_left(
-            gamla.filter(
-                gamla.alljuxt(
-                    gamla.compose_left(str.lower, lambda s: re.search(r"\btodo\b", s)),
-                    lambda s: not re.search(r"(#|//)\sTODO\([a-zA-Z]+\):\s.*", s),
-                ),
+    gamla.compose_left(
+        gamla.filter(
+            gamla.alljuxt(
+                gamla.compose_left(str.lower, lambda s: re.search(r"\btodo\b", s)),
+                lambda s: not re.search(r"(#|//)\sTODO\([a-zA-Z]+\):\s.*", s),
             ),
-            gamla.map(
-                lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
-            ),
+        ),
+        gamla.map(
+            lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
         ),
     ),
     gamla.concat,

--- a/lint/comment.py
+++ b/lint/comment.py
@@ -19,10 +19,6 @@ detect = gamla.compose_left(
                 lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
             ),
         ),
-        gamla.compose_left(
-            gamla.filter(lambda s: re.search(r"^\s*(#|//)[^#\s:]", s)),
-            gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
-        ),
     ),
     gamla.concat,
 )

--- a/lint/comment.py
+++ b/lint/comment.py
@@ -19,10 +19,10 @@ detect = gamla.compose_left(
                 lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
             ),
         ),
-        # gamla.compose_left(
-        #     gamla.filter(lambda s: re.search(r"^\s*//[^\s:]", s)),
-        #     gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
-        # ),
+        gamla.compose_left(
+            gamla.filter(lambda s: re.search(r"^\s*(#|//)[^#\s:]", s)),
+            gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
+        ),
     ),
     gamla.concat,
 )

--- a/lint/comment.py
+++ b/lint/comment.py
@@ -19,10 +19,10 @@ detect = gamla.compose_left(
                 lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
             ),
         ),
-        gamla.compose_left(
-            gamla.filter(lambda s: re.search(r"^\s*//[^\s:]", s)),
-            gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
-        ),
+        # gamla.compose_left(
+        #     gamla.filter(lambda s: re.search(r"^\s*//[^\s:]", s)),
+        #     gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
+        # ),
     ),
     gamla.concat,
 )

--- a/lint/comment.py
+++ b/lint/comment.py
@@ -20,7 +20,7 @@ detect = gamla.compose_left(
             ),
         ),
         gamla.compose_left(
-            gamla.filter(lambda s: re.search(r"^\s*(#|//)[^\s:]", s)),
+            gamla.filter(lambda s: re.search(r"^\s*//[^\s:]", s)),
             gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
         ),
     ),

--- a/lint/comment_test.py
+++ b/lint/comment_test.py
@@ -5,6 +5,7 @@ from lint import comment
 
 def test_good():
     for good_comment in [
+        "## I am a markdown numbered list bullet",
         "# TODO(uri): I am a good comment.",
         "# I am good too.",
         "a = 3  # I am good.",

--- a/lint/comment_test.py
+++ b/lint/comment_test.py
@@ -30,9 +30,7 @@ def test_bad():
         "#todo: do something",
         "# TODO ROM: uncomment when vaccine faq fixed",
         "# TODO (rachel): Remove if not relevant after rescraping novant's vaccine faq.",
-        "#no leading space",
         "// todo(david): I am a bad comment.",
-        "//no leading space",
     ]:
         gamla.pipe(
             bad_comment,


### PR DESCRIPTION
until now, the lint clause

        gamla.compose_left(
            gamla.filter(lambda s: re.search(r"^\s*(#|//)[^\s:]", s)),
            gamla.map(lambda s: f"Comment should start with a space or a colon: [{s}]"),
        ),

prevented us from using “##” and “###” in prompts.

So, we want to to lax the clause.