### PR TITLE
fix TODO warning

### DIFF
--- a/lint/comment.py
+++ b/lint/comment.py
@@ -18,5 +18,5 @@ detect = gamla.compose_left(
             lambda s: f"Malformatted `TODO` syntax (should be `TODO(name): ...`): [{s}]",
         ),
     ),
-    gamla.concat,
+    tuple,
 )


### PR DESCRIPTION
fixing the TODO warning to be straight:

<img width="720" height="592" alt="image" src="https://github.com/user-attachments/assets/09a939be-9ed1-4314-8fa0-07b916361881" />

instead of how it was like this:
<img width="790" height="1000" alt="image" src="https://github.com/user-attachments/assets/2c5a8f85-5234-4a00-b8e8-241c435bc409" />
