### PR TITLE
Exclude tests/cassettes/ from large file check

### DIFF
--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -53,7 +53,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-added-large-files
-        exclude: assistant_configuration.json
+        exclude: assistant_configuration.json|^tests/cassettes/
       - id: debug-statements
       - id: check-json
       - id: pretty-format-json


### PR DESCRIPTION
VCR cassette files can exceed the 500KB limit when recording many LLM interactions in a single test. This excludes `tests/cassettes/` from the `check-added-large-files` hook.

Generated with [Claude Code](https://claude.com/claude-code)