### PR TITLE
Add UUID quality linter to detect hand-typed UUIDs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -33,6 +33,13 @@
   language: python
   files: triplets\.csv$
 
+- id: check-uuid-quality
+  name: check UUID quality
+  description: Detect hand-typed / non-random UUIDs in staged Python changes.
+  entry: check-uuid-quality
+  language: python
+  types: [python]
+
 - id: hyro-pre-commit
   name: Hyro standard hooks
   language: script

--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -48,6 +48,7 @@ repos:
         args: ["--relations", "action/event", "action/suggestions", "action/switch_command", "concept/action", "--"]
       - id: static-analysis
         exclude: vulture_whitelist.py
+      - id: check-uuid-quality
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/lint/uuid_quality.py
+++ b/lint/uuid_quality.py
@@ -1,0 +1,159 @@
+"""Detect hand-typed / non-random UUIDs in Python source files.
+
+Only inspects *added* lines (via ``git diff --cached``), so existing UUIDs are
+grandfathered in.  Test files are skipped because test fixtures commonly use
+placeholder UUIDs on purpose.
+
+Detection
+---------
+1. UUID version — must be v4, v5, or v7.
+2. Interleaved sequential nibbles — catches UUIDs like ``e1d2c3b4-a5f6-…``
+   that satisfy v4 format but were clearly typed by hand.
+3. Straight sequential nibbles — catches runs like ``0a1b2c3d4e5f``.
+"""
+
+import argparse
+import re
+import subprocess
+import uuid
+from typing import Optional, Sequence
+
+_UUID_RE = re.compile(
+    r"""['"]"""
+    r"""([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"""
+    r"""['"]"""
+)
+
+_HUNK_RE = re.compile(r"\+(\d+)")
+
+_ALLOWED_VERSIONS = {4, 5, 7}
+
+_PERMANENT_ALLOWLIST: set[str] = {
+    "00000000-0000-0000-0000-000000000000",
+}
+
+
+def _to_nibbles(hex_str: str) -> list[int]:
+    return [int(c, 16) for c in hex_str.replace("-", "").lower()]
+
+
+def _has_sequential_run(
+    nibbles: list[int], min_run: int, allowed_steps: set[int]
+) -> bool:
+    """Detect an arithmetic run of *min_run* nibbles whose step is in *allowed_steps*."""
+    for start in range(len(nibbles) - min_run + 1):
+        window = nibbles[start : start + min_run]
+        diffs = {(window[i + 1] - window[i]) % 16 for i in range(len(window) - 1)}
+        if len(diffs) == 1 and next(iter(diffs)) in allowed_steps:
+            return True
+    return False
+
+
+_PLUS_MINUS_ONE = {1, 15}
+_ANY_NONZERO = set(range(1, 16))
+
+
+def _has_interleaved_sequence(nibbles: list[int]) -> bool:
+    """Detect patterns where every-other nibble forms an arithmetic run.
+
+    Example: ``e1d2c3b4`` — even nibbles e,d,c,b descend by 1; odd nibbles
+    1,2,3,4 ascend by 1.
+    """
+    return any(
+        _has_sequential_run(nibbles[offset::2], 5, _PLUS_MINUS_ONE)
+        for offset in (0, 1)
+    )
+
+
+def _has_straight_sequence(nibbles: list[int]) -> bool:
+    """Detect a straight run of nibbles with constant non-zero step."""
+    return _has_sequential_run(nibbles, 6, _ANY_NONZERO)
+
+
+def check_uuid(u: str) -> Optional[str]:
+    """Return an error string if *u* looks suspicious, else ``None``."""
+    lower = u.lower()
+
+    if lower in _PERMANENT_ALLOWLIST:
+        return None
+
+    try:
+        parsed = uuid.UUID(lower)
+    except ValueError:
+        return "invalid UUID"
+
+    if parsed.version not in _ALLOWED_VERSIONS:
+        return f"non-random UUID (version={parsed.version})"
+
+    nibbles = _to_nibbles(lower)
+    if _has_interleaved_sequence(nibbles) or _has_straight_sequence(nibbles):
+        return "sequential pattern detected — looks hand-typed"
+
+    return None
+
+
+def _get_added_lines(filepath: str) -> list[tuple[int, str]]:
+    """Return ``(line_number, text)`` pairs for every added line in the staged diff."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "-U0", "--", filepath],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    added: list[tuple[int, str]] = []
+    current_line = 0
+    for diff_line in result.stdout.splitlines():
+        if diff_line.startswith("@@"):
+            match = _HUNK_RE.search(diff_line)
+            if match:
+                current_line = int(match.group(1)) - 1
+        elif diff_line.startswith("+") and not diff_line.startswith("+++"):
+            current_line += 1
+            added.append((current_line, diff_line[1:]))
+        elif not diff_line.startswith("-"):
+            current_line += 1
+
+    return added
+
+
+def _is_test_file(filepath: str) -> bool:
+    return "_test.py" in filepath or "/test_" in filepath
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect hand-typed UUIDs in staged Python changes."
+    )
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+
+    for filepath in args.filenames:
+        if _is_test_file(filepath):
+            continue
+
+        for lineno, line in _get_added_lines(filepath):
+            for match in _UUID_RE.finditer(line):
+                u = match.group(1)
+                error = check_uuid(u)
+                if error:
+                    errors.append(f"  {filepath}:{lineno}: {u} — {error}")
+
+    if errors:
+        print("Suspicious UUIDs in staged changes:\n")  # noqa: T201
+        print("\n".join(errors))  # noqa: T201
+        print(  # noqa: T201
+            '\nFix: python3 -c "import uuid; print(uuid.uuid4())"'
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lint/uuid_quality_test.py
+++ b/lint/uuid_quality_test.py
@@ -1,0 +1,59 @@
+from lint.uuid_quality import check_uuid
+
+
+def test_valid_v4_passes():
+    assert check_uuid("2cfdf745-85a0-41be-9d93-1f89e5b70de7") is None
+
+
+def test_valid_v5_passes():
+    assert check_uuid("037da6b1-3c6d-5522-99c8-b916b4a26f00") is None
+
+
+def test_valid_v7_passes():
+    assert check_uuid("019adb84-22bb-7187-bf34-982378e7e0b9") is None
+
+
+def test_sentinel_zero_uuid_passes():
+    assert check_uuid("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_non_v4_rejected():
+    # v1 UUID
+    assert check_uuid("123e4567-e89b-12d3-a456-426614174000") is not None
+
+
+def test_no_version_rejected():
+    assert check_uuid("1a6f8b4d-3e9c-4a5f-2d7b-6c8e9f3b7d2a") is not None
+
+
+def test_interleaved_sequence_e1d2c3b4():
+    # Valid v4 format but clearly hand-typed
+    assert check_uuid("e1d2c3b4-a5f6-4e7d-8c9b-0a1b2c3d4e5f") is not None
+
+
+def test_interleaved_sequence_a7b8c9d0():
+    assert check_uuid("a7b8c9d0-e1f2-4a3b-5c6d-7e8f9a0b1c2d") is not None
+
+
+def test_straight_sequence_12345678():
+    assert check_uuid("12345678-1234-1234-1234-123456789123") is not None
+
+
+def test_interleaved_sequence_a1b2c3d4():
+    assert check_uuid("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d") is not None
+
+
+def test_real_world_uuid_not_flagged():
+    # Randomly generated UUIDs from the nlu-runtime codebase
+    assert check_uuid("66bdefbe-74fa-4a25-bbaf-d44260927af4") is None
+    assert check_uuid("901f1282-73d7-4952-b048-00ab694d6744") is None
+    assert check_uuid("fd99e55b-3b2c-43e8-a2c0-6d5e5adea31f") is None
+
+
+def test_scheduling_eligibility_bb_flagged():
+    # Known bad UUID already in the codebase
+    assert check_uuid("a3c7f8d2-9b4e-4a1c-8f2d-5e6a7b8c9d0e") is not None
+
+
+def test_invalid_uuid_string():
+    assert check_uuid("not-a-uuid-at-all-nope-nope12345678") is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ make-api-doc = "lint.make_api_doc:main"
 format-csv = "lint.format_csv:main"
 format-assistant-configuration = "lint.format_assistant_configuration:main"
 validate-triplets = "lint.validate_triplets:main"
+check-uuid-quality = "lint.uuid_quality:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
We've had recurring issues with developers using sequential/patterned UUIDs (e.g. e1d2c3b4-a5f6-..., a7b8c9d0-...) as configurable keys, which can cause collisions. This adds a pre-commit hook that catches these before they land.

The hook only inspects added lines (via git diff --cached) so existing UUIDs are grandfathered in. Test files are skipped since fixtures use placeholder UUIDs intentionally.

Detection: UUID version check (must be v4/v5/v7) + sequential nibble pattern detection (interleaved and straight arithmetic runs).