### PR TITLE
Engine 3512 deployment env var check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,6 +40,13 @@
   language: python
   types: [python]
 
+- id: check-deployment-env-vars
+  name: Check deployment env var consistency
+  description: Warn when a new env var is added to some Helm deployments but not others.
+  entry: check-deployment-env-vars
+  language: python
+  files: deploy/.+/templates/deployment\.yaml$
+
 - id: hyro-pre-commit
   name: Hyro standard hooks
   language: script

--- a/lint/check_deployment_env_vars.py
+++ b/lint/check_deployment_env_vars.py
@@ -5,11 +5,11 @@ Only inspects added lines in the staged diff (``git diff --cached``), so
 existing per-service differences are grandfathered in.
 
 The exceptions file (``deploy/env-var-exceptions.json``) in the consuming repo
-documents vars that are intentionally absent from certain deployments:
+documents vars that are intentionally absent from certain deployments, for example:
 
     {
-      "WIDGET_SERVER_SMS_ADDRESS": {
-        "bot-archive": "transitive import only, not used by this service"
+      "SOME_VAR": {
+        "some-service": "reason why not needed here"
       }
     }
 """
@@ -18,7 +18,7 @@ import argparse
 import json
 import re
 import subprocess
-from pathlib import Path
+import pathlib
 from typing import Optional, Sequence
 
 import gamla
@@ -27,24 +27,32 @@ _ENV_VAR_RE = re.compile(r"^\s*-\s*name:\s*([A-Z][A-Z0-9_]+)\s*$")
 _EXCEPTIONS_FILE = "deploy/env-var-exceptions.json"
 _DEPLOYMENT_RE = re.compile(r"deploy/[^/]+/templates/deployment\.yaml$")
 
+_vars_from_content = gamla.compose_left(
+    str.splitlines,
+    gamla.map_filter_empty(
+        gamla.compose_left(
+            _ENV_VAR_RE.match,
+            lambda match: match.group(1) if match else None,
+        )
+    ),
+    frozenset,
+)
+
 _vars_from_added_diff_lines = gamla.compose_left(
     str.splitlines,
     gamla.filter(lambda line: line.startswith("+") and not line.startswith("+++")),
     gamla.map(lambda line: line[1:]),
-    gamla.filter(_ENV_VAR_RE.match),
-    gamla.map(gamla.compose_left(_ENV_VAR_RE.match, lambda match: match.group(1))),
-    frozenset,
-)
-
-_vars_from_content = gamla.compose_left(
-    str.splitlines,
-    gamla.filter(_ENV_VAR_RE.match),
-    gamla.map(gamla.compose_left(_ENV_VAR_RE.match, lambda match: match.group(1))),
-    frozenset,
+    "\n".join,
+    _vars_from_content,
 )
 
 
-def _unexcused_missing(var, source_chart, all_vars_by_chart, exceptions):
+def _unexcused_missing(
+    var: str,
+    source_chart: str,
+    all_vars_by_chart: dict[str, frozenset[str]],
+    exceptions: dict[str, dict[str, str]],
+) -> list[str]:
     return sorted(
         chart
         for chart, chart_vars in all_vars_by_chart.items()
@@ -54,7 +62,19 @@ def _unexcused_missing(var, source_chart, all_vars_by_chart, exceptions):
     )
 
 
-def _format_error(var, source_chart, missing_charts):
+def _stale_exceptions(
+    new_vars_by_chart: dict[str, frozenset[str]],
+    exceptions: dict[str, dict[str, str]],
+) -> tuple[str, ...]:
+    return tuple(
+        f"{var} is now in {source_chart} but {source_chart} is still listed in {_EXCEPTIONS_FILE} — consider removing it."
+        for source_chart, new_vars in new_vars_by_chart.items()
+        for var in sorted(new_vars)
+        if source_chart in exceptions.get(var, {})
+    )
+
+
+def _format_error(var: str, source_chart: str, missing_charts: list[str]) -> str:
     return (
         f"{var} (added to {source_chart}) is missing from: {', '.join(missing_charts)}\n"
         f"  Add it to those deployments, or document exceptions in {_EXCEPTIONS_FILE}:\n"
@@ -66,16 +86,11 @@ def _format_error(var, source_chart, missing_charts):
     )
 
 
-def _stale_exceptions(new_vars_by_chart, exceptions):
-    return tuple(
-        f"{var} is now in {source_chart} but {source_chart} is still listed in {_EXCEPTIONS_FILE} — consider removing it."
-        for source_chart, new_vars in new_vars_by_chart.items()
-        for var in sorted(new_vars)
-        if source_chart in exceptions.get(var, {})
-    )
-
-
-def detect(new_vars_by_chart, all_vars_by_chart, exceptions):
+def detect(
+    new_vars_by_chart: dict[str, frozenset[str]],
+    all_vars_by_chart: dict[str, frozenset[str]],
+    exceptions: dict[str, dict[str, str]],
+) -> tuple[str, ...]:
     return tuple(
         _format_error(var, source_chart, missing)
         for source_chart, new_vars in new_vars_by_chart.items()
@@ -84,17 +99,13 @@ def detect(new_vars_by_chart, all_vars_by_chart, exceptions):
     )
 
 
-def _staged_diff(filepath):
+def _staged_diff(filepath: str) -> str:
     result = subprocess.run(
         ["git", "diff", "--cached", "-U0", "--", filepath],
         capture_output=True,
         text=True,
     )
     return result.stdout if result.returncode == 0 else ""
-
-
-def _chart_name(deployment_path):
-    return Path(deployment_path).parts[1]
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -110,18 +121,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     all_deployments = {
         deployment.parts[1]: _vars_from_content(deployment.read_text())
-        for deployment in Path("deploy").glob("*/templates/deployment.yaml")
+        for deployment in pathlib.Path("deploy").glob("*/templates/deployment.yaml")
     }
     if len(all_deployments) < 2:
         return 0
 
-    exceptions_path = Path(_EXCEPTIONS_FILE)
+    exceptions_path = pathlib.Path(_EXCEPTIONS_FILE)
     exceptions = (
         json.loads(exceptions_path.read_text()) if exceptions_path.exists() else {}
     )
 
     new_vars_by_chart = {
-        _chart_name(filepath): _vars_from_added_diff_lines(_staged_diff(filepath))
+        pathlib.Path(filepath).parts[1]: _vars_from_added_diff_lines(_staged_diff(filepath))
         for filepath in staged_files
     }
 

--- a/lint/check_deployment_env_vars.py
+++ b/lint/check_deployment_env_vars.py
@@ -66,6 +66,15 @@ def _format_error(var, source_chart, missing_charts):
     )
 
 
+def _stale_exceptions(new_vars_by_chart, exceptions):
+    return tuple(
+        f"{var} is now in {source_chart} but {source_chart} is still listed in {_EXCEPTIONS_FILE} — consider removing it."
+        for source_chart, new_vars in new_vars_by_chart.items()
+        for var in sorted(new_vars)
+        if source_chart in exceptions.get(var, {})
+    )
+
+
 def detect(new_vars_by_chart, all_vars_by_chart, exceptions):
     return tuple(
         _format_error(var, source_chart, missing)
@@ -115,6 +124,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         _chart_name(filepath): _vars_from_added_diff_lines(_staged_diff(filepath))
         for filepath in staged_files
     }
+
+    for warning in _stale_exceptions(new_vars_by_chart, exceptions):
+        print(warning)  # noqa: T201
 
     errors = detect(new_vars_by_chart, all_deployments, exceptions)
     if errors:

--- a/lint/check_deployment_env_vars.py
+++ b/lint/check_deployment_env_vars.py
@@ -1,0 +1,129 @@
+"""Check that newly added env vars in Helm deployment templates are either
+present in all other deployments or documented in an exceptions file.
+
+Only inspects added lines in the staged diff (``git diff --cached``), so
+existing per-service differences are grandfathered in.
+
+The exceptions file (``deploy/env-var-exceptions.json``) in the consuming repo
+documents vars that are intentionally absent from certain deployments:
+
+    {
+      "WIDGET_SERVER_SMS_ADDRESS": {
+        "bot-archive": "transitive import only, not used by this service"
+      }
+    }
+"""
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence
+
+import gamla
+
+_ENV_VAR_RE = re.compile(r"^\s*-\s*name:\s*([A-Z][A-Z0-9_]+)\s*$")
+_EXCEPTIONS_FILE = "deploy/env-var-exceptions.json"
+_DEPLOYMENT_RE = re.compile(r"deploy/[^/]+/templates/deployment\.yaml$")
+
+_vars_from_added_diff_lines = gamla.compose_left(
+    str.splitlines,
+    gamla.filter(lambda line: line.startswith("+") and not line.startswith("+++")),
+    gamla.map(lambda line: line[1:]),
+    gamla.filter(_ENV_VAR_RE.match),
+    gamla.map(gamla.compose_left(_ENV_VAR_RE.match, lambda match: match.group(1))),
+    frozenset,
+)
+
+_vars_from_content = gamla.compose_left(
+    str.splitlines,
+    gamla.filter(_ENV_VAR_RE.match),
+    gamla.map(gamla.compose_left(_ENV_VAR_RE.match, lambda match: match.group(1))),
+    frozenset,
+)
+
+
+def _unexcused_missing(var, source_chart, all_vars_by_chart, exceptions):
+    return sorted(
+        chart
+        for chart, chart_vars in all_vars_by_chart.items()
+        if chart != source_chart
+        and var not in chart_vars
+        and chart not in exceptions.get(var, {})
+    )
+
+
+def _format_error(var, source_chart, missing_charts):
+    return (
+        f"{var} (added to {source_chart}) is missing from: {', '.join(missing_charts)}\n"
+        f"  Add it to those deployments, or document exceptions in {_EXCEPTIONS_FILE}:\n"
+        f'    "{var}": {{\n'
+        + "".join(
+            f'      "{chart}": "reason why not needed here",\n' for chart in missing_charts
+        )
+        + "    }"
+    )
+
+
+def detect(new_vars_by_chart, all_vars_by_chart, exceptions):
+    return tuple(
+        _format_error(var, source_chart, missing)
+        for source_chart, new_vars in new_vars_by_chart.items()
+        for var in sorted(new_vars)
+        if (missing := _unexcused_missing(var, source_chart, all_vars_by_chart, exceptions))
+    )
+
+
+def _staged_diff(filepath):
+    result = subprocess.run(
+        ["git", "diff", "--cached", "-U0", "--", filepath],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _chart_name(deployment_path):
+    return Path(deployment_path).parts[1]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check deployment env var consistency across Helm charts."
+    )
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    staged_files = [filepath for filepath in args.filenames if _DEPLOYMENT_RE.search(filepath)]
+    if not staged_files:
+        return 0
+
+    all_deployments = {
+        deployment.parts[1]: _vars_from_content(deployment.read_text())
+        for deployment in Path("deploy").glob("*/templates/deployment.yaml")
+    }
+    if len(all_deployments) < 2:
+        return 0
+
+    exceptions_path = Path(_EXCEPTIONS_FILE)
+    exceptions = (
+        json.loads(exceptions_path.read_text()) if exceptions_path.exists() else {}
+    )
+
+    new_vars_by_chart = {
+        _chart_name(filepath): _vars_from_added_diff_lines(_staged_diff(filepath))
+        for filepath in staged_files
+    }
+
+    errors = detect(new_vars_by_chart, all_deployments, exceptions)
+    if errors:
+        print("Deployment env var consistency check failed:")  # noqa: T201
+        for error in errors:
+            print(error)  # noqa: T201
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lint/check_deployment_env_vars_test.py
+++ b/lint/check_deployment_env_vars_test.py
@@ -66,6 +66,26 @@ def test_no_error_when_no_new_vars():
     )
 
 
+def test_stale_exception_warning_when_var_added_to_excepted_chart():
+    gamla.pipe(
+        check_deployment_env_vars._stale_exceptions(
+            {"service-a": frozenset({"SOME_VAR"})},
+            {"SOME_VAR": {"service-a": "not needed"}},
+        ),
+        gamla.assert_that(gamla.nonempty),
+    )
+
+
+def test_no_stale_exception_when_chart_not_excepted():
+    gamla.pipe(
+        check_deployment_env_vars._stale_exceptions(
+            {"service-a": frozenset({"SOME_VAR"})},
+            {"SOME_VAR": {"service-b": "not needed"}},
+        ),
+        gamla.assert_that(gamla.empty),
+    )
+
+
 def test_vars_from_added_diff_lines_detects_new_var():
     gamla.pipe(
         """\

--- a/lint/check_deployment_env_vars_test.py
+++ b/lint/check_deployment_env_vars_test.py
@@ -1,0 +1,88 @@
+import gamla
+
+from lint import check_deployment_env_vars
+
+_CHARTS = {
+    "service-a": frozenset({"COMMON_VAR", "SERVICE_A_ONLY"}),
+    "service-b": frozenset({"COMMON_VAR", "SERVICE_B_ONLY"}),
+    "service-c": frozenset({"COMMON_VAR"}),
+}
+
+_NO_EXCEPTIONS = {}
+
+
+def test_no_error_when_var_present_in_all_charts():
+    gamla.pipe(
+        check_deployment_env_vars.detect(
+            {"service-a": frozenset({"COMMON_VAR"})},
+            _CHARTS,
+            _NO_EXCEPTIONS,
+        ),
+        gamla.assert_that(gamla.empty),
+    )
+
+
+def test_error_when_var_missing_from_other_chart():
+    gamla.pipe(
+        check_deployment_env_vars.detect(
+            {"service-a": frozenset({"NEW_VAR"})},
+            _CHARTS,
+            _NO_EXCEPTIONS,
+        ),
+        gamla.assert_that(gamla.nonempty),
+    )
+
+
+def test_no_error_when_missing_chart_is_excepted():
+    gamla.pipe(
+        check_deployment_env_vars.detect(
+            {"service-a": frozenset({"NEW_VAR"})},
+            _CHARTS,
+            {"NEW_VAR": {"service-b": "not needed", "service-c": "not needed"}},
+        ),
+        gamla.assert_that(gamla.empty),
+    )
+
+
+def test_error_when_only_some_missing_charts_are_excepted():
+    gamla.pipe(
+        check_deployment_env_vars.detect(
+            {"service-a": frozenset({"NEW_VAR"})},
+            _CHARTS,
+            {"NEW_VAR": {"service-b": "not needed"}},
+        ),
+        gamla.assert_that(gamla.nonempty),
+    )
+
+
+def test_no_error_when_no_new_vars():
+    gamla.pipe(
+        check_deployment_env_vars.detect(
+            {"service-a": frozenset()},
+            _CHARTS,
+            _NO_EXCEPTIONS,
+        ),
+        gamla.assert_that(gamla.empty),
+    )
+
+
+def test_vars_from_added_diff_lines_detects_new_var():
+    gamla.pipe(
+        """\
+--- a/deploy/assistant/templates/deployment.yaml
++++ b/deploy/assistant/templates/deployment.yaml
+@@ -10,0 +11,2 @@
++            - name: TRITON_RUNTIME_SERVICE
++              value: {{ .Values.tritonRuntimeService }}
+""",
+        check_deployment_env_vars._vars_from_added_diff_lines,
+        gamla.assert_that(gamla.inside("TRITON_RUNTIME_SERVICE")),
+    )
+
+
+def test_vars_from_added_diff_lines_ignores_removed_lines():
+    gamla.pipe(
+        "-            - name: OLD_VAR\n+            - name: NEW_VAR\n",
+        check_deployment_env_vars._vars_from_added_diff_lines,
+        gamla.assert_that(gamla.complement(gamla.inside("OLD_VAR"))),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ format-csv = "lint.format_csv:main"
 format-assistant-configuration = "lint.format_assistant_configuration:main"
 validate-triplets = "lint.validate_triplets:main"
 check-uuid-quality = "lint.uuid_quality:main"
+check-deployment-env-vars = "lint.check_deployment_env_vars:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
Adds a check-deployment-env-vars hook that fires when a new env var is added to some Helm deployment templates but not others. It reads only staged diff lines, so existing per-service differences are not flagged. Intentional omissions can be documented in deploy/env-var-exceptions.json in the consuming repo. Also adds a soft warning when a var is added to a chart that's still listed in the exceptions file.