### PR TITLE
ENGINE-3236: restore Python 3.14 requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lint"
 version = "1"
 description = "Python static analysis linting tools."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 dependencies = ["gamla"]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
Restore `requires-python = ">=3.14"` (reverses the 3.11 downgrade in `a5abf1a`). `.travis.yml` and the README already target 3.14; this re-tightens package metadata so lint requires 3.14 again, for the ecosystem 3.14 cutover.