### PR TITLE
ENGINE-3236: bump hyro-hooks self-ref to the Python 3.14 lint commit

### DIFF
--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -37,7 +37,7 @@ repos:
           - types-requests
 
   - repo: https://github.com/hyroai/lint
-    rev: 8193c8e80a55cea907b6e641e89343275197799b
+    rev: a686cfe39da54ba62325708a549cc0e1222461ed
     hooks:
       - id: format-csv
         files: triplets.csv


### PR DESCRIPTION
## Summary
Bumps the `hyro-hooks.yaml` self-reference `rev` from `8193c8e` (the Python 3.11 revert) to master HEAD `a686cfe` — the #59 merge that restored `requires-python >= 3.14`. This points consumers of the shared hyro-hooks config at a Python-3.14 lint, completing the cutover and reversing the 3.11 self-ref bump (#57 / `93bd08f`).