### PR TITLE
CORE-46: bump every pre-commit hook to latest, fixing Python 3.14 breakage

### DIFF
--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 8.0.1
     hooks:
       - id: isort
 
   - repo: https://github.com/ambv/black
-    rev: 22.12.0
+    rev: 26.5.1
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         exclude: vulture_whitelist.py
@@ -25,7 +25,7 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v2.3.0
     hooks:
       - id: mypy
         args: [--follow-imports=silent, --ignore-missing-imports]
@@ -37,7 +37,7 @@ repos:
           - types-requests
 
   - repo: https://github.com/hyroai/lint
-    rev: a686cfe39da54ba62325708a549cc0e1222461ed
+    rev: 20cf0c57a53d526fffeb2e499bdf0288c41b3e9c
     hooks:
       - id: format-csv
         files: triplets.csv
@@ -51,7 +51,7 @@ repos:
       - id: check-uuid-quality
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         exclude: assistant_configuration.json|^tests/cassettes/
@@ -62,27 +62,27 @@ repos:
         exclude: .versions.json
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         entry: codespell --ignore-words=.codespell_ignore --quiet-level=4 --check-filenames --ignore-regex=".*codespell-ignore$"
-        exclude: \.(csv|json|txt)$|.*spanish.*
+        exclude: \.(csv|json|txt|pdf)$|.*spanish.*
 
   - repo: https://github.com/myint/autoflake
-    rev: v2.0.0
+    rev: v2.3.3
     hooks:
       - id: autoflake
         entry: autoflake -i --remove-all-unused-imports
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: [ '--baseline', '.secrets.baseline' ]
         exclude: .cloud_cache.json|.gitlab-ci.yml|.pre-commit-config.yaml
 
   - repo: https://github.com/semgrep/semgrep
-    rev: 'v1.73.0'
+    rev: 'v1.171.0'
     hooks:
       - id: semgrep
         args: [ '--metrics', 'off', '--config', 'https://raw.githubusercontent.com/hyroai/lint/master/rule.yaml', '--error' ]


### PR DESCRIPTION
## Summary

Python 3.14 removed the deprecated `ast.Str` / `ast.Num` / `ast.Bytes` / `ast.NameConstant` / `ast.Ellipsis` aliases, which broke two pinned hooks:

- **flake8 6.0.0** (pyflakes 3.0.1) raises `AttributeError: module 'ast' has no attribute 'Str'` and aborts the entire run at the first affected file, so the gate reports nothing while still failing every commit that touches such a file.
- **black 22.12.0** hits the same crash inside its AST-equivalence safety check. Latent, since it only runs when black actually has to reformat a file.

There is no smaller flake8 bump: 6.0.0 pins `pyflakes<3.1`, and the first pyflakes without `ast.Str` is 3.1.0.

All remaining hooks are bumped to latest at the same time. semgrep was not broken by 3.14, but v1.73.0 is below semgrep.dev's 1.76.0 support floor.

| hook | from | to |
|---|---|---|
| isort | 5.12.0 | 8.0.1 |
| black | 22.12.0 | 26.5.1 |
| flake8 | 6.0.0 | 7.3.0 |
| mypy | v1.5.1 | v2.3.0 |
| pre-commit-hooks | v4.4.0 | v6.0.0 |
| codespell | v2.2.2 | v2.4.3 |
| autoflake | v2.0.0 | v2.3.3 |
| detect-secrets | v1.4.0 | v1.5.0 |
| semgrep | v1.73.0 | v1.171.0 |
| hyroai/lint self-ref | a686cfe | 20cf0c5 |

`pre-commit autoupdate` resolves isort to a prerelease (9.0.0b1) and semgrep to v1.165.0 (the newest tag reachable from its default branch); both are pinned to the latest stable release instead.

PDFs are added to the codespell exclude — extracted PDF text produces only false positives.