### PR TITLE
CORE-46: bump hyro-hooks self-ref to the merged hook-update commit

### DIFF
--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -37,7 +37,7 @@ repos:
           - types-requests
 
   - repo: https://github.com/hyroai/lint
-    rev: 20cf0c57a53d526fffeb2e499bdf0288c41b3e9c
+    rev: 752f5f92c9461bfe122934861785df92f721ebad
     hooks:
       - id: format-csv
         files: triplets.csv


### PR DESCRIPTION
## Summary

Post-merge follow-up to #61. Points `hyro-hooks.yaml`'s inner `hyroai/lint` reference at master HEAD `752f5f9` — the #61 merge that moved every hook to latest for the Python 3.14 cutover.

Same step `eda72a7` did after #59. The self-reference necessarily lags one merge behind, since it cannot name its own merge commit.

This only governs which revision supplies the lint package's own hooks (`format-csv`, `static-analysis`, `validate-triplets`, `check-uuid-quality`). The previous target `20cf0c5` already required Python 3.14, so nothing was broken — this just keeps the reference current so consumers pinning this commit get a coherent set.

## Jira

https://hyro-ai.atlassian.net/browse/CORE-46