### PR TITLE
CORE-27: exclude uv.lock from the large-file check

### DIFF
--- a/hyro-hooks.yaml
+++ b/hyro-hooks.yaml
@@ -54,7 +54,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
-        exclude: assistant_configuration.json|^tests/cassettes/
+        exclude: assistant_configuration.json|^tests/cassettes/|uv\.lock$
       - id: debug-statements
       - id: check-json
       - id: pretty-format-json


### PR DESCRIPTION
Lockfiles are intentionally large (nlu-runtime's is ~590 KB against the 500 KB limit) and are reviewed as generated artifacts. Part of the pip→uv migration (CORE-27).